### PR TITLE
Added status code to the error response body

### DIFF
--- a/src/Phapi/Middleware/Mistake/Mistake.php
+++ b/src/Phapi/Middleware/Mistake/Mistake.php
@@ -225,6 +225,10 @@ class Mistake implements ErrorMiddleware
         // Prepare body
         $body = [ 'errors' => [] ];
 
+        if (!empty($statusCode = $exception->getStatusCode())) {
+            $body['errors']['statusCode'] = $statusCode;
+        }
+
         // Check if a message has been defined
         if (!empty($message = $exception->getMessage())) {
             $body['errors']['message'] = $message;


### PR DESCRIPTION
Since JSONP cant use the http status code on errors we have to include the status code in some way. And no matter what serializer/format is used it's beneficial to include the status code in the body (if an error occurs).